### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,4 +1,4 @@
-name: NodeJS with Webpack
+name: NodeJS CI
 
 on:
   push:
@@ -22,7 +22,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Install dependencies
+      run: npm install
+
     - name: Build
-      run: |
-        npm install
-        npx webpack
+      run: npm run build


### PR DESCRIPTION
## Summary
- fix CI build script to use `npm run build` instead of webpack

## Testing
- `npm run lint` *(fails: No files matching)*
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6870f1cb2b7c8332977ff202d9261017