### PR TITLE
Fix dev server port collision

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -13,9 +13,10 @@ export default defineConfig({
   },
   plugins: [tsconfigPaths(), react(), tagger()],
   server: {
-    port: "4028",
+    // Use the default Vite port and allow automatic fallback if it's busy
+    port: 5173,
     host: "0.0.0.0",
-    strictPort: true,
+    strictPort: false,
     allowedHosts: ['.amazonaws.com', '.builtwithrocket.new']
   }
 });


### PR DESCRIPTION
## Summary
- fix port collision by switching to Vite's default port and allowing fallback

## Testing
- `npm run lint` *(fails: No files matching the pattern "src" were found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fde4feac83328e542b80796db032