### PR TITLE
Allow port fallback for dev server

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -15,7 +15,7 @@ export default defineConfig({
   server: {
     port: "4028",
     host: "0.0.0.0",
-    strictPort: true,
+    strictPort: false,
     allowedHosts: ['.amazonaws.com', '.builtwithrocket.new']
   }
 });


### PR DESCRIPTION
## Summary
- update `vite.config.mjs` to disable `strictPort`

## Testing
- `npm run lint` *(fails: No files matching the pattern "src" were found)*

------
https://chatgpt.com/codex/tasks/task_e_687100341b94833289573595b1fb71ed